### PR TITLE
Fix rewrite-migrate-java references

### DIFF
--- a/rewrite-weblogic/README.md
+++ b/rewrite-weblogic/README.md
@@ -37,11 +37,11 @@ Clone your project to your local machine.
 ```shell
 mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
   -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-weblogic:LATEST \
-  -Drewrite.activeRecipes=com.oracle.weblogic.rewrite.upgradeTo1411
+  -Drewrite.activeRecipes=com.oracle.weblogic.rewrite.UpgradeTo1411
 ```
 
 mvn -U org.openrewrite.maven:rewrite-maven-plugin:dryRunNoFork \
-  -Drewrite.activeRecipes=com.oracle.weblogic.rewrite.upgradeTo1411
+  -Drewrite.activeRecipes=com.oracle.weblogic.rewrite.UpgradeTo1411
 
 
 ### Running using maven and adding `<plugin>` on the `pom.xml`
@@ -55,7 +55,7 @@ mvn -U org.openrewrite.maven:rewrite-maven-plugin:dryRunNoFork \
             <version>5.43.0</version>
             <configuration>
                 <activeRecipes>
-                    <recipe>com.oracle.weblogic.rewrite.upgradeTo1412</recipe>
+                    <recipe>com.oracle.weblogic.rewrite.UpgradeTo1412</recipe>
                 </activeRecipes>
             </configuration>
             <dependencies>
@@ -111,7 +111,7 @@ mvn test
 
 | Composite Recipes | Recipes | Description |
 | --- | --- | --- |
-| Migrate to WebLogic 14.1.2 and Java 21 | [com.oracle.weblogic.rewrite.upgradeTo1412](resources/META-INF/rewrite/weblogic-14.1.2.yaml) <br/> com.oracle.weblogic.rewrite.UpgradeWeblogicMavenPropertyVersion <br/> [org.openrewrite.java.migrate.UpgradeToJava21](https://docs.openrewrite.org/recipes/java/migrate/upgradetojava21) | - Applies changes required for migrating apps to WebLogic 14.1.2 <br/> - Upgrade WebLogic Version <br/> - Upgrade Java version to 21|
-| Migrate to WebLogic 14.1.2 and Java 17 | [com.oracle.weblogic.rewrite.upgradeTo1412](resources/META-INF/rewrite/weblogic-14.1.2.yaml) <br/> com.oracle.weblogic.rewrite.UpgradeWeblogicMavenPropertyVersion <br/> [org.openrewrite.java.migrate.UpgradeToJava17](https://docs.openrewrite.org/recipes/java/migrate/upgradetojava17) | - Applies changes required for migrating apps to WebLogic 14.1.2 <br/> - Upgrade WebLogic Version <br/> - Upgrade Java version to 17|
-| Migrate to WebLogic 14.1.1 and Java 11 | [com.oracle.weblogic.rewrite.upgradeTo1411](resources/META-INF/rewrite/weblogic-14.1.1.yaml) <br/> [org.openrewrite.java.migrate.Java8toJava11](https://docs.openrewrite.org/recipes/java/migrate/java8tojava11) <br/> [org.openrewrite.maven.ChangePropertyValue](https://docs.openrewrite.org/recipes/maven/changepropertyvalue) <br/> [org.openrewrite.maven.UpgradeParentVersion](https://docs.openrewrite.org/recipes/maven/upgradeparentversion) | - Applies changes required for migrating apps to WebLogic 14.1.1 <br/> - Upgrade Java version to 11 <br/> - Change property to weblogic 14.1.1 <br/> - Upgrade WebLogic Version on parent|
+| Migrate to WebLogic 14.1.2 and Java 21 | [com.oracle.weblogic.rewrite.UpgradeTo1412](resources/META-INF/rewrite/weblogic-14.1.2.yaml) <br/> com.oracle.weblogic.rewrite.UpgradeWeblogicMavenPropertyVersion <br/> [org.openrewrite.java.migrate.UpgradeToJava21](https://docs.openrewrite.org/recipes/java/migrate/upgradetojava21) | - Applies changes required for migrating apps to WebLogic 14.1.2 <br/> - Upgrade WebLogic Version <br/> - Upgrade Java version to 21|
+| Migrate to WebLogic 14.1.2 and Java 17 | [com.oracle.weblogic.rewrite.UpgradeTo1412](resources/META-INF/rewrite/weblogic-14.1.2.yaml) <br/> com.oracle.weblogic.rewrite.UpgradeWeblogicMavenPropertyVersion <br/> [org.openrewrite.java.migrate.UpgradeToJava17](https://docs.openrewrite.org/recipes/java/migrate/upgradetojava17) | - Applies changes required for migrating apps to WebLogic 14.1.2 <br/> - Upgrade WebLogic Version <br/> - Upgrade Java version to 17|
+| Migrate to WebLogic 14.1.1 and Java 11 | [com.oracle.weblogic.rewrite.UpgradeTo1411](resources/META-INF/rewrite/weblogic-14.1.1.yaml) <br/> [org.openrewrite.java.migrate.Java8toJava11](https://docs.openrewrite.org/recipes/java/migrate/java8tojava11) <br/> [org.openrewrite.maven.ChangePropertyValue](https://docs.openrewrite.org/recipes/maven/changepropertyvalue) <br/> [org.openrewrite.maven.UpgradeParentVersion](https://docs.openrewrite.org/recipes/maven/upgradeparentversion) | - Applies changes required for migrating apps to WebLogic 14.1.1 <br/> - Upgrade Java version to 11 <br/> - Change property to weblogic 14.1.1 <br/> - Upgrade WebLogic Version on parent|
 

--- a/rewrite-weblogic/pom.xml
+++ b/rewrite-weblogic/pom.xml
@@ -66,6 +66,11 @@
           <scope>compile</scope>
       </dependency>
       <dependency>
+          <groupId>org.openrewrite.recipe</groupId>
+          <artifactId>rewrite-migrate-java</artifactId>
+          <scope>runtime</scope>
+      </dependency>
+      <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
         <version>1.18.34</version>

--- a/rewrite-weblogic/src/main/resources/META-INF/rewrite/weblogic-14.1.1.yaml
+++ b/rewrite-weblogic/src/main/resources/META-INF/rewrite/weblogic-14.1.1.yaml
@@ -37,7 +37,7 @@
 # SOFTWARE.
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: com.oracle.weblogic.rewrite.upgradeTo1411
+name: com.oracle.weblogic.rewrite.UpgradeTo1411
 displayName: Migrate to WebLogic 14.1.1
 description: This recipe will apply changes required for migrating to WebLogic 14.1.1
 tags:

--- a/rewrite-weblogic/src/main/resources/META-INF/rewrite/weblogic-14.1.2.yaml
+++ b/rewrite-weblogic/src/main/resources/META-INF/rewrite/weblogic-14.1.2.yaml
@@ -37,7 +37,7 @@
 # SOFTWARE.
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: com.oracle.weblogic.rewrite.upgradeToWeblogic1412Java21
+name: com.oracle.weblogic.rewrite.UpgradeToWeblogic1412Java21
 displayName: Migrate to WebLogic 14.1.2 and Java 21
 description: This recipe will apply changes required for migrating to WebLogic 14.1.2 and Java 21
 tags:
@@ -48,7 +48,7 @@ recipeList:
   - com.oracle.weblogic.rewrite.UpdateBuildToWebLogic1412
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: com.oracle.weblogic.rewrite.upgradeToWeblogic1412Java17
+name: com.oracle.weblogic.rewrite.UpgradeToWeblogic1412Java17
 displayName: Migrate to WebLogic 14.1.2 and Java 17
 description: This recipe will apply changes required for migrating to WebLogic 14.1.2 and Java 21
 tags:


### PR DESCRIPTION
Without the dependency on `rewrite-migrate-java` you can't reference the `UpgradeToJava21` recipe and others.

I've also renamed the recipes here to match the casing expected elsewhere; this will become more apparent when there's other recipe classes right next to these declarative recipes, and helps folks find the recipes with the expected identifiers.