### PR TITLE
Add custom recipe to convert usages of some deprecated Jakarta Faces to their replacements, which have slightly different signatures.

### DIFF
--- a/rewrite-weblogic/pom.xml
+++ b/rewrite-weblogic/pom.xml
@@ -120,6 +120,18 @@
           <artifactId>rewrite-test</artifactId>
           <scope>test</scope>
       </dependency>
+      <dependency>
+          <groupId>jakarta.platform</groupId>
+          <artifactId>jakarta.jakartaee-api</artifactId>
+          <version>9.1.0</version>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>jakarta.platform</groupId>
+          <artifactId>jakarta.jakartaee-web-api</artifactId>
+          <version>9.1.0</version>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 
   <build>

--- a/rewrite-weblogic/src/main/java/com/oracle/weblogic/rewrite/jakarta/ChangeJakartaFacesMethodCalls.java
+++ b/rewrite-weblogic/src/main/java/com/oracle/weblogic/rewrite/jakarta/ChangeJakartaFacesMethodCalls.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * https://oss.oracle.com/licenses/upl.
+ *
+ */
+package com.oracle.weblogic.rewrite.jakarta;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.NlsRewrite;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+import java.util.regex.Pattern;
+
+/**
+ * ChangeJakartaFacesMethodCalls updates the following deprecated method calls
+ * 1. Application.createValueBinding("#{somestringexpression}") =>
+ *       Application.createValueExpression(FacesContext.getCurrentInstance().getELContext(), "#{somestringexpression}", Object.class)
+ * 2. ValueExpression.getValue(someFacesContext) => ValueExpression.getValue(someFacesContext.getELContext())
+ */
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ChangeJakartaFacesMethodCalls extends Recipe {
+
+    private static final String GET_EXPRESSION_FACTORY_METHOD_NAME = "getExpressionFactory";
+    private static final String CREATE_VALUE_EXPRESSION_METHOD_NAME = "createValueExpression";
+    private static final String GET_EL_CONTEXT_METHOD_CALL = "FacesContext.getCurrentInstance().getELContext()";
+
+    private static final MethodMatcher createValueBindingMatcher = new MethodMatcher(
+            "*.faces.application.Application createValueBinding(java.lang.String)");
+    private static final MethodMatcher getValueMatcher = new MethodMatcher(
+            "jakarta.el.ValueExpression getValue(jakarta.faces.context.FacesContext)");
+    private static final Pattern VALUE_EXPRESSION_PATTERN
+            = Pattern.compile("jakarta.el.ValueExpression");
+    private static final Pattern FACES_CONTEXT_PATTERN = Pattern.compile("jakarta.faces.context.FacesContext");
+
+    @Override
+    public @NlsRewrite.DisplayName @NotNull String getDisplayName() {
+        return "ChangeJakartaFacesMethodCalls";
+    }
+
+    @Override
+    public @NlsRewrite.Description @NotNull String getDescription() {
+        return "Handle method call changes for deprecated Faces/EL methods with different arguments from the original.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation methodCall, ExecutionContext ctx) {
+                J.MethodInvocation m = methodCall;
+                // Find out whether method invocation matches
+                if (createValueBindingMatcher.matches(methodCall)) {
+                    m = replaceCreateValueBinding(methodCall);
+                } else if (isGetValueMethod(methodCall)) {
+                    m = changeGetValueArgument(methodCall);
+                }
+                return super.visitMethodInvocation(m, ctx);
+            }
+
+            private J.MethodInvocation changeGetValueArgument(J.MethodInvocation methodCall) {
+                J.Identifier objectIdentifier = (J.Identifier) methodCall.getSelect();
+                if (objectIdentifier == null) {
+                    return methodCall;
+                }
+                Expression firstArg = methodCall.getArguments().get(0);
+                if (firstArg.getType() != null && firstArg.getType().isAssignableFrom(FACES_CONTEXT_PATTERN)) {
+                    final String newArg = methodCall.getArguments().get(0) + ".getELContext()";
+                    final String newGetValueTemplateStr = String.format("%s.%s(%s)",
+                            objectIdentifier.getSimpleName(),
+                            methodCall.getSimpleName(),
+                            newArg);
+                    JavaTemplate newGetValueTemplate = JavaTemplate
+                            .builder(newGetValueTemplateStr).build();
+                    return newGetValueTemplate.apply(getCursor(), methodCall.getCoordinates().replace());
+                }
+                return methodCall;
+            }
+
+            private J.MethodInvocation replaceCreateValueBinding(J.MethodInvocation methodCall) {
+                J.Identifier objectIdentifier = (J.Identifier) methodCall.getSelect();
+                if (objectIdentifier == null) {
+                    return methodCall;
+                }
+                final String newMethodCallTemplate = String.format(
+                        "%s.%s().%s(%s, #{any(java.lang.String)}, Object.class)",
+                        objectIdentifier.getSimpleName(),
+                        GET_EXPRESSION_FACTORY_METHOD_NAME,
+                        CREATE_VALUE_EXPRESSION_METHOD_NAME,
+                        // 1st argument is an EL context
+                        GET_EL_CONTEXT_METHOD_CALL
+                        // 2nd argument will be filled in with the String argument from the original method call
+                        // 3rd argument is already inlined in the format string above.
+                );
+                JavaTemplate createValueExpressionTemplate = JavaTemplate
+                        .builder(newMethodCallTemplate)
+                        .imports("jakarta.faces.context.FacesContext")
+                        .build();
+
+                // apply the template and substitute with the argument from the original method call
+                return createValueExpressionTemplate.apply(
+                        getCursor(), methodCall.getCoordinates().replace(), methodCall.getArguments().get(0));
+            }
+        };
+    }
+
+    private boolean isGetValueMethod(J.MethodInvocation methodCall) {
+        if (methodCall.getMethodType() != null) {
+            return getValueMatcher.matches(methodCall);
+        }
+        Expression objForMethodCall = methodCall.getSelect();
+        // in unit tests, the method type comes through as null, so the matcher does not work.
+        return (objForMethodCall != null && objForMethodCall.getType() != null &&
+                objForMethodCall.getType().isAssignableFrom(VALUE_EXPRESSION_PATTERN) &&
+                methodCall.getArguments().size() == 1 &&
+                methodCall.getArguments().get(0).getType() != null &&
+                methodCall.getArguments().get(0).getType().isAssignableFrom(FACES_CONTEXT_PATTERN)
+        );
+    }
+}

--- a/rewrite-weblogic/src/main/resources/META-INF/rewrite/jakarta-faces-3.yaml
+++ b/rewrite-weblogic/src/main/resources/META-INF/rewrite/jakarta-faces-3.yaml
@@ -34,6 +34,7 @@ recipeList:
   - com.oracle.weblogic.rewrite.jakarta.JavaxWebXmlToJakartaWebXml5
   - com.oracle.weblogic.rewrite.jakarta.FacesJNDINamesChanged3
   - com.oracle.weblogic.rewrite.jakarta.RemovedJakartaFaces3ExpressionLanguageClasses
+  - com.oracle.weblogic.rewrite.jakarta.UpdateJakartaFacesMethodCalls
   - com.oracle.weblogic.rewrite.jakarta.RemovedJakartaFaces3ResourceResolver
   - com.oracle.weblogic.rewrite.jakarta.RemovedStateManagerMethods3
   - com.oracle.weblogic.rewrite.jakarta.FacesManagedBeansRemoved3
@@ -322,6 +323,15 @@ recipeList:
       oldFullyQualifiedTypeName: javax.faces.el.ReferenceSyntaxException
       newFullyQualifiedTypeName: jakarta.el.ELException
       ignoreDefinition: true
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.oracle.weblogic.rewrite.jakarta.UpdateJakartaFacesMethodCalls
+displayName: Update deprecated Faces method calls
+description: >
+  Custom recipe to handle method call changes for deprecated Faces/EL methods where the method argument lists have
+  changed. This recipe should be run _after_ all the Jakarta Faces related type changes are completed.
+recipeList:
+  - com.oracle.weblogic.rewrite.jakarta.ChangeJakartaFacesMethodCalls
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: com.oracle.weblogic.rewrite.jakarta.FacesManagedBeansRemoved3

--- a/rewrite-weblogic/src/test/java/com/oracle/weblogic/rewrite/jakarta/ChangeJakartaFacesMethodCallsTest.java
+++ b/rewrite-weblogic/src/test/java/com/oracle/weblogic/rewrite/jakarta/ChangeJakartaFacesMethodCallsTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * https://oss.oracle.com/licenses/upl.
+ *
+ */
+package com.oracle.weblogic.rewrite.jakarta;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class ChangeJakartaFacesMethodCallsTest implements RewriteTest {
+    private static final String JAKARTA_EE9_API_JAR_NAME = "jakarta.jakartaee-api";
+    private static final String JAKARTA_WEBAPI9_JAR_NAME = "jakarta.jakartaee-web-api";
+    @Override
+    public void defaults(RecipeSpec spec) {
+        try {
+            spec.parser(JavaParser.fromJavaVersion()
+                .classpath(JAKARTA_EE9_API_JAR_NAME, JAKARTA_WEBAPI9_JAR_NAME))
+                    .recipe(new ChangeJakartaFacesMethodCalls())
+                    // the code provided for the "before" case is after partial transformation by other Rewrite recipes,
+                    // before it gets to this recipe. That code is not expected to compile, so we skip type validations.
+                    .typeValidationOptions(TypeValidation.none());
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testValueExpressionAndBinding() {
+        rewriteRun(
+                java(
+                """
+                            package com.mypackage;
+
+                            import jakarta.el.ValueExpression;
+                            import jakarta.faces.application.Application;
+                            import jakarta.faces.context.FacesContext;
+
+                            public class MyClass {
+                                public void getStockNews() {
+                                    FacesContext facesContext = FacesContext.getCurrentInstance();
+                                    Application application = facesContext.getApplication();
+                                    ValueExpression binding = application.createValueBinding("#{stockTickerBeanVal}");
+                                    Object b = binding.getValue(facesContext);
+                                }
+                            }
+                        """,
+                  """
+                            package com.mypackage;
+
+                            import jakarta.el.ValueExpression;
+                            import jakarta.faces.application.Application;
+                            import jakarta.faces.context.FacesContext;
+
+                            public class MyClass {
+                                public void getStockNews() {
+                                    FacesContext facesContext = FacesContext.getCurrentInstance();
+                                    Application application = facesContext.getApplication();
+                                    ValueExpression binding = application.getExpressionFactory().createValueExpression(FacesContext.getCurrentInstance().getELContext(), "#{stockTickerBeanVal}", Object.class);
+                                    Object b = binding.getValue(facesContext.getELContext());
+                                }
+                            }
+                        """)
+        );
+    }
+
+    /**
+     * Test a case that has references to other methods which have the same name as the ones the recipe matches for,
+     * but not on the same data types. These should not match and there should be no change to the code.
+     */
+    @Test
+    public void testShouldNotMakeChanges() {
+        rewriteRun(java(
+                """
+                            package com.mypackage;
+
+                            public class MyClass {
+                                public void getStockNews() {
+                                    Application application = new Application();
+                                    ValueExpression ve = application.createValueBinding("#{stockTickerBeanVal}");
+                                    String s = ve.getValue();
+                                }
+                            }
+
+                            class Application {
+                                public ValueExpression createValueBinding(String val) {
+                                    return new ValueExpression("dummy return value");
+                                }
+                            }
+
+                            class ValueExpression {
+                                private String value;
+                                public ValueExpression(String value) {
+                                    this.value = value;
+                                }
+                                public String getValue() {
+                                    return this.value;
+                                }
+                            }
+                        """
+        ));
+    }
+}


### PR DESCRIPTION
Also adds a unit test, includes the recipe in the jakarta-faces-3.yaml, and adds some test scoped dependencies for use by the parser in OpenRewrite tests.

Example diff resulting from this new recipe:
```
-            ValueBinding binding = application.createValueBinding("#{stockTickerBean}");
-            StockTickerBean stockTickerBean = (StockTickerBean)binding.getValue(facesContext);
+            ValueExpression binding = application.getExpressionFactory().createValueExpression(FacesContext.getCurrentInstance().getELContext(), "#{stockTickerBean}", Object.class);
+            StockTickerBean stockTickerBean = (StockTickerBean)binding.getValue(facesContext.getELContext());
```