### PR TITLE
Recipe fixes for the cargo-tracker sample application

### DIFF
--- a/rewrite-weblogic/src/main/resources/META-INF/rewrite/weblogic-15.1.1.yaml
+++ b/rewrite-weblogic/src/main/resources/META-INF/rewrite/weblogic-15.1.1.yaml
@@ -48,6 +48,7 @@ recipeList:
   - com.oracle.weblogic.rewrite.UpdateBuildToWebLogic1511
   - com.oracle.weblogic.rewrite.CheckAndCommentOutDeprecations1511
   - com.oracle.weblogic.rewrite.MigrateWebLogicSchemasTo1511
+  - com.oracle.weblogic.rewrite.ChangeJakartaInjectAPIDependencyScope
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: com.oracle.weblogic.rewrite.UpdateBuildToWebLogic1511
@@ -276,3 +277,21 @@ tags:
   - schemas
 recipeList:
   - com.oracle.weblogic.rewrite.WebLogicResourceDeploymentPlanXmlNamespace1412
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.oracle.weblogic.rewrite.ChangeJakartaInjectAPIDependencyScope
+displayName: Change the jakarta.inject-api dependency to scope provided when jakartaee-api 9.x is provided.
+description: This recipe will change the jakarta.inject-api dependency scope to provided when jakarta.jakartaee-api version 9.x is provided in WebLogic 15.1.1. This prevents the jakarta.inject-api jar from being deployed to WebLogic which can cause class conflicts.
+tags:
+  - weblogic
+preconditions:
+  - org.openrewrite.java.dependencies.DependencyInsight:
+      groupIdPattern: jakarta.platform
+      artifactIdPattern: jakarta.jakartaee-api
+      version: 9.x
+      scope: provided
+recipeList:
+  - org.openrewrite.maven.ChangeDependencyScope:
+      groupId: jakarta.inject
+      artifactId: jakarta.inject-api
+      newScope: provided

--- a/rewrite-weblogic/src/main/resources/META-INF/rewrite/weblogic-15.1.1.yaml
+++ b/rewrite-weblogic/src/main/resources/META-INF/rewrite/weblogic-15.1.1.yaml
@@ -49,6 +49,7 @@ recipeList:
   - com.oracle.weblogic.rewrite.CheckAndCommentOutDeprecations1511
   - com.oracle.weblogic.rewrite.MigrateWebLogicSchemasTo1511
   - com.oracle.weblogic.rewrite.ChangeJakartaInjectAPIDependencyScope
+  - com.oracle.weblogic.rewrite.ChangeJAXBBindAPIDependencyScope
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: com.oracle.weblogic.rewrite.UpdateBuildToWebLogic1511
@@ -294,4 +295,22 @@ recipeList:
   - org.openrewrite.maven.ChangeDependencyScope:
       groupId: jakarta.inject
       artifactId: jakarta.inject-api
+      newScope: provided
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.oracle.weblogic.rewrite.ChangeJAXBBindAPIDependencyScope
+displayName: Change the jakarta.xml.bind-api dependency to scope provided when jakartaee-api 9.x is provided.
+description: This recipe will change the jakarta.xml.bind-api dependency scope to provided when jakarta.jakartaee-api version 9.x is provided in WebLogic 15.1.1. This prevents the jakarta.xml.bind-api jar from being deployed to WebLogic which can cause class conflicts.
+tags:
+  - weblogic
+preconditions:
+  - org.openrewrite.java.dependencies.DependencyInsight:
+      groupIdPattern: jakarta.platform
+      artifactIdPattern: jakarta.jakartaee-api
+      version: 9.x
+      scope: provided
+recipeList:
+  - org.openrewrite.maven.ChangeDependencyScope:
+      groupId: jakarta.xml.bind
+      artifactId: jakarta.xml.bind-api
       newScope: provided


### PR DESCRIPTION
This PR fixes the deployment of the cargo-tracker sample application on WebLogic 15.1.1. It includes the following changes:

1. Ensures the scope of the jakarta.inject-api and jakarta.xml.bind-api jars is "provided" so that they do not get bundled and deployed. Deploying those jars to WebLogic 15.1.1.1 results in CDI and class loading conflict errors. I also included a DependencyInsight on jakarta.jakartaee-api 9.x to try to limit when this change is applied, so as not to potentially break other apps.
