### PR TITLE
Fix primefaces dependency version

### DIFF
--- a/rewrite-weblogic/src/main/resources/META-INF/rewrite/jakarta-faces-3.yaml
+++ b/rewrite-weblogic/src/main/resources/META-INF/rewrite/jakarta-faces-3.yaml
@@ -408,7 +408,6 @@ recipeList:
       groupId: org.primefaces
       artifactId: primefaces
       newVersion: 13.0.x
-      versionPattern: '-LTS'
   - org.openrewrite.maven.ChangeDependencyClassifier:
       groupId: org.primefaces.extensions
       artifactId: primefaces-extensions
@@ -417,7 +416,6 @@ recipeList:
       groupId: org.primefaces.extensions
       artifactId: primefaces-extensions
       newVersion: 13.0.x
-      versionPattern: '-LTS'
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.omnifaces
       artifactId: omnifaces


### PR DESCRIPTION
The primefaces versions have changed in maven central. It seems as though the artifacts recently had a "-LTS" suffix that no longer exists. This change drops the suffix so that the recipe can find the correct versions.