### PR TITLE
Fixed one of the examples

### DIFF
--- a/rewrite-weblogic/README.md
+++ b/rewrite-weblogic/README.md
@@ -118,7 +118,7 @@ Example that includes the Hibernate recipe running with the WebLogic 15.1.1 BETA
 ```shell
 mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
   -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-migrate-java:RELEASE,com.oracle.weblogic.rewrite:rewrite-weblogic:LATEST,org.openrewrite.recipe:rewrite-spring:RELEASE,org.openrewrite.recipe:rewrite-hibernate:RELEASE \
-  -Drewrite.activeRecipes=org.openrewrite.java.migrate.UpgradeToJava21,com.oracle.weblogic.rewrite.JakartaEE9_1,com.oracle.weblogic.rewrite.UpgradeTo1511,com.oracle.weblogic.rewrite.spring.framework.UpgradeToSpringFramework_6_2,com.oracle.weblogic.rewrite.hibernate.MigrateHibernateToJakartaEE9 \
+  -Drewrite.activeRecipes=org.openrewrite.java.migrate.UpgradeToJava21,com.oracle.weblogic.rewrite.JakartaEE9_1,com.oracle.weblogic.rewrite.UpgradeTo1511,com.oracle.weblogic.rewrite.spring.framework.UpgradeToSpringFramework_6_2,com.oracle.weblogic.rewrite.hibernate.MigrateHibernate4JakartaEE9 \
   -Drewrite.exportDatatables=true
 ```
 


### PR DESCRIPTION
MigrateHibernate4JakartaEE9 not MigrateHibernateToJakartaEE9 appears to be the correct name in one of the examples

under the heading "Example that includes the Hibernate recipe running with the WebLogic 15.1.1 BETA, Java 21, and Spring Framework 6.2 recipes." that next block seems to have the wrong name - mvn suggested the correct one and it worked.