### PR TITLE
Fix jakarta.ws.rs-api dependency scope to be provided

### DIFF
--- a/rewrite-weblogic/src/main/resources/META-INF/rewrite/weblogic-15.1.1.yaml
+++ b/rewrite-weblogic/src/main/resources/META-INF/rewrite/weblogic-15.1.1.yaml
@@ -50,6 +50,7 @@ recipeList:
   - com.oracle.weblogic.rewrite.MigrateWebLogicSchemasTo1511
   - com.oracle.weblogic.rewrite.ChangeJakartaInjectAPIDependencyScope
   - com.oracle.weblogic.rewrite.ChangeJAXBBindAPIDependencyScope
+  - com.oracle.weblogic.rewrite.ChangeJakartaWebServiceRSAPIDependencyScope
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: com.oracle.weblogic.rewrite.UpdateBuildToWebLogic1511
@@ -377,4 +378,22 @@ recipeList:
   - org.openrewrite.maven.ChangeDependencyScope:
       groupId: jakarta.xml.bind
       artifactId: jakarta.xml.bind-api
+      newScope: provided
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.oracle.weblogic.rewrite.ChangeJakartaWebServiceRSAPIDependencyScope
+displayName: Change the jakarta.ws.rs-api dependency to scope provided when jakartaee-api 9.x is provided.
+description: This recipe will change the jakarta.ws.rs-api dependency scope to provided when jakarta.jakartaee-api version 9.x is provided in WebLogic 15.1.1. This prevents the jakarta.ws.rs-api jar from being deployed to WebLogic which can cause class conflicts.
+tags:
+  - weblogic
+preconditions:
+  - org.openrewrite.java.dependencies.DependencyInsight:
+      groupIdPattern: jakarta.platform
+      artifactIdPattern: jakarta.jakartaee-api
+      version: 9.x
+      scope: provided
+recipeList:
+  - org.openrewrite.maven.ChangeDependencyScope:
+      groupId: jakarta.ws.rs
+      artifactId: jakarta.ws.rs-api
       newScope: provided


### PR DESCRIPTION
A recent change to openrewrite/rewrite-migrate-java results in the jakarta.ws.rs-api dependency being added to the pom when migrating. The jar that gets bundled with the application conflicts with a WebLogic version of the jar and causes the application deployment to fail.

The fix is to patch the dependency so that the scope is "provided". We have had to apply this same fix to a couple of other dependencies that cause WebLogic jar conflicts.
