### PR TITLE
Upgrade org.springframework.data:spring-data-jpa to v3.4.6

### DIFF
--- a/rewrite-weblogic/src/main/resources/META-INF/rewrite/spring-framework-6.2.yaml
+++ b/rewrite-weblogic/src/main/resources/META-INF/rewrite/spring-framework-6.2.yaml
@@ -32,6 +32,7 @@ recipeList:
   - com.oracle.weblogic.rewrite.spring.framework.ReplaceWebLogicLoadTimeWeaver
   - org.openrewrite.java.spring.data.UpgradeSpringData_2_7
   - com.oracle.weblogic.rewrite.spring.data.UpgradeSpringDataBom
+  - com.oracle.weblogic.rewrite.spring.data.UpgradeSpringDataJpa
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: com.oracle.weblogic.rewrite.spring.framework.DefaultServletHandler
@@ -98,3 +99,16 @@ recipeList:
       groupId: org.springframework.data
       artifactId: spring-data-bom
       newVersion: 2024.1.x
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.oracle.weblogic.rewrite.spring.data.UpgradeSpringDataJpa
+displayName: Upgrade Spring Data JPA to 3.4.6
+description: Upgrade Spring Data JPA to 3.4.6 version, which is the version used by spring-data-bom v2024.1.x
+tags:
+  - springdata
+  - springframework
+recipeList:
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springframework.data
+      artifactId: spring-data-jpa
+      newVersion: 3.4.6


### PR DESCRIPTION
Updated recipe com.oracle.weblogic.rewrite.spring.framework.UpgradeToSpringFramework_6_2 to upgrade org.springframework.data:spring-data-jpa to v3.4.6. The existing recipe updates spring-data-bom to 2024.1.x, where org.springframework.data:spring-data-jpa:3.4.6 is one of the managed dependencies.