### PR TITLE
Add -parameters compiler argument for Jackson to be able to deserialize the constructor parameters of a class

### DIFF
--- a/rewrite-weblogic/pom.xml
+++ b/rewrite-weblogic/pom.xml
@@ -142,6 +142,9 @@
                           <version>1.18.36</version>
                       </path>
                   </annotationProcessorPaths>
+                  <compilerArgs>
+                      <arg>-parameters</arg>
+                  </compilerArgs>
               </configuration>
           </plugin>
           <plugin>


### PR DESCRIPTION
This change is required for Jackson to deserialize the constructor parameters of a class, as documented in https://docs.openrewrite.org/authoring-recipes/recipe-development-environment.