### PR TITLE
Set `recursive` on the `jakarta.sql.rowset` to `javax.sql.rowset` rename

### DIFF
--- a/rewrite-weblogic/src/main/resources/META-INF/rewrite/jakarta-ee-9.1.yaml
+++ b/rewrite-weblogic/src/main/resources/META-INF/rewrite/jakarta-ee-9.1.yaml
@@ -318,6 +318,7 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: jakarta.sql.rowset
       newPackageName: javax.sql.rowset
+      recursive: true
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: com.oracle.weblogic.rewrite.jakarta.UpgradeCommonOpenSourceLibraries


### PR DESCRIPTION
`jakarta.sql.rowset` → `javax.sql.rowset` omits `recursive`, so types in the two subpackages are never renamed:

| old | new |
| --- | --- |
| `jakarta.sql.rowset.serial` | `javax.sql.rowset.serial` |
| `jakarta.sql.rowset.spi` | `javax.sql.rowset.spi` |

Both exist in the JDK, so recursion is safe and required here. The sibling `jakarta.sql` → `javax.sql` rule is left alone; it does not need to recurse once this one does.

Context: openrewrite/rewrite#8382 pins `ChangePackage.recursive` to mean non-recursive when unset, which makes this dependency explicit. Correct either way.